### PR TITLE
section8

### DIFF
--- a/projects/08/FunctionCalls/FibonacciElement/FibonacciElement.asm
+++ b/projects/08/FunctionCalls/FibonacciElement/FibonacciElement.asm
@@ -1,0 +1,481 @@
+	@Sys.init
+	0;JMP
+//decl funcMain.fibonacci0
+(Main.fibonacci)
+//decl funcMain.fibonacci0end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//pushconstant2
+	@2
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant2end
+//lt
+//JLT
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M-D
+	@TMain0
+	D;JLT
+	D=0
+	@ECMain0
+	0;JMP
+(TMain0)
+	D=-1
+	@ECMain0
+	0;JMP
+	(ECMain0)
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//JLTend
+//ltend
+//ifIF_TRUE
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@IF_TRUE
+	D;JNE
+//ifIF_TRUEend
+//gotoIF_FALSE
+	@IF_FALSE
+	0;JMP
+//gotoIF_FALSEend
+//label
+(IF_TRUE)
+//label end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//return
+	@LCL
+	D=M
+	@FRAME
+	M=D
+	@5
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@RET
+	M=D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	@ARG
+	D=M
+	@SP
+	M=D+1
+	@1
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THAT
+	M=D
+	@2
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THIS
+	M=D
+	@3
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@ARG
+	M=D
+	@4
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@LCL
+	M=D
+	@RET
+	A=M
+	0;JMP
+//return end
+//label
+(IF_FALSE)
+//label end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//pushconstant2
+	@2
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant2end
+//sub
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M-D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//subend
+//callMain.fibonacci1
+	@reMain.fibonacci0
+	D=A
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+	@LCL
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@ARG
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THIS
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THAT
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@SP
+	D=M
+	@1
+	D=D-A
+	@5
+	D=D-A
+	@ARG
+	M=D
+	@SP
+	D=M
+	@LCL
+	M=D
+//gotoMain.fibonacci
+	@Main.fibonacci
+	0;JMP
+//gotoMain.fibonacciend
+(reMain.fibonacci0)
+//callMain.fibonacci1end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//pushconstant1
+	@1
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant1end
+//sub
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M-D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//subend
+//callMain.fibonacci1
+	@reMain.fibonacci1
+	D=A
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+	@LCL
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@ARG
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THIS
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THAT
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@SP
+	D=M
+	@1
+	D=D-A
+	@5
+	D=D-A
+	@ARG
+	M=D
+	@SP
+	D=M
+	@LCL
+	M=D
+//gotoMain.fibonacci
+	@Main.fibonacci
+	0;JMP
+//gotoMain.fibonacciend
+(reMain.fibonacci1)
+//callMain.fibonacci1end
+//add
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M+D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//addend
+//return
+	@LCL
+	D=M
+	@FRAME
+	M=D
+	@5
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@RET
+	M=D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	@ARG
+	D=M
+	@SP
+	M=D+1
+	@1
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THAT
+	M=D
+	@2
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THIS
+	M=D
+	@3
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@ARG
+	M=D
+	@4
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@LCL
+	M=D
+	@RET
+	A=M
+	0;JMP
+//return end
+//decl funcSys.init0
+(Sys.init)
+//decl funcSys.init0end
+//pushconstant4
+	@4
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant4end
+//callMain.fibonacci1
+	@reMain.fibonacci2
+	D=A
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+	@LCL
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@ARG
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THIS
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THAT
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@SP
+	D=M
+	@1
+	D=D-A
+	@5
+	D=D-A
+	@ARG
+	M=D
+	@SP
+	D=M
+	@LCL
+	M=D
+//gotoMain.fibonacci
+	@Main.fibonacci
+	0;JMP
+//gotoMain.fibonacciend
+(reMain.fibonacci2)
+//callMain.fibonacci1end
+//label
+(WHILE)
+//label end
+//gotoWHILE
+	@WHILE
+	0;JMP
+//gotoWHILEend
+(END)
+	@END
+	0;JMP

--- a/projects/08/FunctionCalls/NestedCall/NestedCall.asm
+++ b/projects/08/FunctionCalls/NestedCall/NestedCall.asm
@@ -1,0 +1,674 @@
+	@Sys.init
+	0;JMP
+//decl funcSys.init0
+(Sys.init)
+//decl funcSys.init0end
+//pushconstant4000
+	@4000
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant4000end
+//poppointer0
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@3
+	M=D
+//poppointer0end
+//pushconstant5000
+	@5000
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant5000end
+//poppointer1
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@4
+	M=D
+//poppointer1end
+//callSys.main0
+	@reSys.main0
+	D=A
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+	@LCL
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@ARG
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THIS
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THAT
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@SP
+	D=M
+	@0
+	D=D-A
+	@5
+	D=D-A
+	@ARG
+	M=D
+	@SP
+	D=M
+	@LCL
+	M=D
+//gotoSys.main
+	@Sys.main
+	0;JMP
+//gotoSys.mainend
+(reSys.main0)
+//callSys.main0end
+//poptemp1
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@6
+	M=D
+//poptemp1end
+//label
+(LOOP)
+//label end
+//gotoLOOP
+	@LOOP
+	0;JMP
+//gotoLOOPend
+//decl funcSys.main5
+(Sys.main)
+//pushconstant0
+	@0
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant0end
+//pushconstant0
+	@0
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant0end
+//pushconstant0
+	@0
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant0end
+//pushconstant0
+	@0
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant0end
+//pushconstant0
+	@0
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant0end
+//decl funcSys.main5end
+//pushconstant4001
+	@4001
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant4001end
+//poppointer0
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@3
+	M=D
+//poppointer0end
+//pushconstant5001
+	@5001
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant5001end
+//poppointer1
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@4
+	M=D
+//poppointer1end
+//pushconstant200
+	@200
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant200end
+//poplocal1
+	@1
+	D=A
+	@LCL
+	M=M+D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@LCL
+	A=M
+	M=D
+	@1
+	D=A
+	@LCL
+	M=M-D
+//poplocal1end
+//pushconstant40
+	@40
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant40end
+//poplocal2
+	@2
+	D=A
+	@LCL
+	M=M+D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@LCL
+	A=M
+	M=D
+	@2
+	D=A
+	@LCL
+	M=M-D
+//poplocal2end
+//pushconstant6
+	@6
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant6end
+//poplocal3
+	@3
+	D=A
+	@LCL
+	M=M+D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@LCL
+	A=M
+	M=D
+	@3
+	D=A
+	@LCL
+	M=M-D
+//poplocal3end
+//pushconstant123
+	@123
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant123end
+//callSys.add121
+	@reSys.add121
+	D=A
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+	@LCL
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@ARG
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THIS
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THAT
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@SP
+	D=M
+	@1
+	D=D-A
+	@5
+	D=D-A
+	@ARG
+	M=D
+	@SP
+	D=M
+	@LCL
+	M=D
+//gotoSys.add12
+	@Sys.add12
+	0;JMP
+//gotoSys.add12end
+(reSys.add121)
+//callSys.add121end
+//poptemp0
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@5
+	M=D
+//poptemp0end
+//pushlocal0
+	@0
+	D=A
+	@LCL
+	M=M+D
+	@LCL
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@LCL
+	M=M-D
+//pushlocal0end
+//pushlocal1
+	@1
+	D=A
+	@LCL
+	M=M+D
+	@LCL
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@1
+	D=A
+	@LCL
+	M=M-D
+//pushlocal1end
+//pushlocal2
+	@2
+	D=A
+	@LCL
+	M=M+D
+	@LCL
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@2
+	D=A
+	@LCL
+	M=M-D
+//pushlocal2end
+//pushlocal3
+	@3
+	D=A
+	@LCL
+	M=M+D
+	@LCL
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@3
+	D=A
+	@LCL
+	M=M-D
+//pushlocal3end
+//pushlocal4
+	@4
+	D=A
+	@LCL
+	M=M+D
+	@LCL
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@4
+	D=A
+	@LCL
+	M=M-D
+//pushlocal4end
+//add
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M+D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//addend
+//add
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M+D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//addend
+//add
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M+D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//addend
+//add
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M+D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//addend
+//return
+	@LCL
+	D=M
+	@FRAME
+	M=D
+	@5
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@RET
+	M=D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	@ARG
+	D=M
+	@SP
+	M=D+1
+	@1
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THAT
+	M=D
+	@2
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THIS
+	M=D
+	@3
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@ARG
+	M=D
+	@4
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@LCL
+	M=D
+	@RET
+	A=M
+	0;JMP
+//return end
+//decl funcSys.add120
+(Sys.add12)
+//decl funcSys.add120end
+//pushconstant4002
+	@4002
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant4002end
+//poppointer0
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@3
+	M=D
+//poppointer0end
+//pushconstant5002
+	@5002
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant5002end
+//poppointer1
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@4
+	M=D
+//poppointer1end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//pushconstant12
+	@12
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant12end
+//add
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M+D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//addend
+//return
+	@LCL
+	D=M
+	@FRAME
+	M=D
+	@5
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@RET
+	M=D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	@ARG
+	D=M
+	@SP
+	M=D+1
+	@1
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THAT
+	M=D
+	@2
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THIS
+	M=D
+	@3
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@ARG
+	M=D
+	@4
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@LCL
+	M=D
+	@RET
+	A=M
+	0;JMP
+//return end
+(END)
+	@END
+	0;JMP

--- a/projects/08/FunctionCalls/SimpleFunction/SimpleFunction.asm
+++ b/projects/08/FunctionCalls/SimpleFunction/SimpleFunction.asm
@@ -1,0 +1,188 @@
+//init
+//initend
+//decl funcSimpleFunction.test2
+(SimpleFunction.test)
+	@0
+	D=A
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//decl funcSimpleFunction.test2end
+//pushlocal0
+	@0
+	D=A
+	@LCL
+	M=M+D
+	@LCL
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@LCL
+	M=M-D
+//pushlocal0end
+//pushlocal1
+	@1
+	D=A
+	@LCL
+	M=M+D
+	@LCL
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@1
+	D=A
+	@LCL
+	M=M-D
+//pushlocal1end
+//add
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M+D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//addend
+//not
+//!
+	@SP
+	A=M-1
+	M=!M
+//!end
+//notend
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//add
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M+D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//addend
+//pushargument1
+	@1
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@1
+	D=A
+	@ARG
+	M=M-D
+//pushargument1end
+//sub
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M-D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//subend
+//return
+	@LCL
+	D=M
+	@FRAME
+	M=D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	D=A
+	@SP
+	M=D+1
+	@1
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THAT
+	M=D
+	@2
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THIS
+	M=D
+	@3
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@ARG
+	M=D
+	@4
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@LCL
+	M=D
+	@5
+	D=A
+	@FRAME
+	A=M-D
+	0;JMP
+//return end
+(END)
+	@END
+	0;JMP

--- a/projects/08/FunctionCalls/StaticsTest/StaticsTest.asm
+++ b/projects/08/FunctionCalls/StaticsTest/StaticsTest.asm
@@ -1,0 +1,702 @@
+//init
+	@261
+	D=A
+	@SP
+	M=D
+	@Sys.init
+	0;JMP
+//decl funcClass1.set0
+(Class1.set)
+//decl funcClass1.set0end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//popstatic0
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@Class1.0
+	M=D
+//popstatic0end
+//pushargument1
+	@1
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@1
+	D=A
+	@ARG
+	M=M-D
+//pushargument1end
+//popstatic1
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@Class1.1
+	M=D
+//popstatic1end
+//pushconstant0
+	@0
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant0end
+//return
+	@LCL
+	D=M
+	@FRAME
+	M=D
+	@5
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@RET
+	M=D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	@ARG
+	D=M
+	@SP
+	M=D+1
+	@1
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THAT
+	M=D
+	@2
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THIS
+	M=D
+	@3
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@ARG
+	M=D
+	@4
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@LCL
+	M=D
+	@RET
+	A=M
+	0;JMP
+//return end
+//decl funcClass1.get0
+(Class1.get)
+//decl funcClass1.get0end
+//pushstatic0
+	@Class1.0
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushstatic0end
+//pushstatic1
+	@Class1.1
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushstatic1end
+//sub
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M-D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//subend
+//return
+	@LCL
+	D=M
+	@FRAME
+	M=D
+	@5
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@RET
+	M=D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	@ARG
+	D=M
+	@SP
+	M=D+1
+	@1
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THAT
+	M=D
+	@2
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THIS
+	M=D
+	@3
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@ARG
+	M=D
+	@4
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@LCL
+	M=D
+	@RET
+	A=M
+	0;JMP
+//return end
+//decl funcSys.init0
+(Sys.init)
+//decl funcSys.init0end
+//pushconstant6
+	@6
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant6end
+//pushconstant8
+	@8
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant8end
+//callClass1.set2
+	@Class1.set$RETURN0
+	D=A
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+	@LCL
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@ARG
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THIS
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THAT
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@SP
+	D=M
+	@2
+	D=D-A
+	@5
+	D=D-A
+	@ARG
+	M=D
+	@SP
+	D=M
+	@LCL
+	M=D
+//gotoClass1.set
+	@Class1.set
+	0;JMP
+//gotoClass1.setend
+(Class1.set$RETURN0)
+//callClass1.set2end
+//poptemp0
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@5
+	M=D
+//poptemp0end
+//pushconstant23
+	@23
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant23end
+//pushconstant15
+	@15
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant15end
+//callClass2.set2
+	@Class2.set$RETURN1
+	D=A
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+	@LCL
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@ARG
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THIS
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THAT
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@SP
+	D=M
+	@2
+	D=D-A
+	@5
+	D=D-A
+	@ARG
+	M=D
+	@SP
+	D=M
+	@LCL
+	M=D
+//gotoClass2.set
+	@Class2.set
+	0;JMP
+//gotoClass2.setend
+(Class2.set$RETURN1)
+//callClass2.set2end
+//poptemp0
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@5
+	M=D
+//poptemp0end
+//callClass1.get0
+	@Class1.get$RETURN2
+	D=A
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+	@LCL
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@ARG
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THIS
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THAT
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@SP
+	D=M
+	@0
+	D=D-A
+	@5
+	D=D-A
+	@ARG
+	M=D
+	@SP
+	D=M
+	@LCL
+	M=D
+//gotoClass1.get
+	@Class1.get
+	0;JMP
+//gotoClass1.getend
+(Class1.get$RETURN2)
+//callClass1.get0end
+//callClass2.get0
+	@Class2.get$RETURN3
+	D=A
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+	@LCL
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@ARG
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THIS
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@THAT
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@SP
+	D=M
+	@0
+	D=D-A
+	@5
+	D=D-A
+	@ARG
+	M=D
+	@SP
+	D=M
+	@LCL
+	M=D
+//gotoClass2.get
+	@Class2.get
+	0;JMP
+//gotoClass2.getend
+(Class2.get$RETURN3)
+//callClass2.get0end
+//label
+(WHILE)
+//label end
+//gotoWHILE
+	@WHILE
+	0;JMP
+//gotoWHILEend
+//decl funcClass2.set0
+(Class2.set)
+//decl funcClass2.set0end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//popstatic0
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@Class2.0
+	M=D
+//popstatic0end
+//pushargument1
+	@1
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@1
+	D=A
+	@ARG
+	M=M-D
+//pushargument1end
+//popstatic1
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@Class2.1
+	M=D
+//popstatic1end
+//pushconstant0
+	@0
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant0end
+//return
+	@LCL
+	D=M
+	@FRAME
+	M=D
+	@5
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@RET
+	M=D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	@ARG
+	D=M
+	@SP
+	M=D+1
+	@1
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THAT
+	M=D
+	@2
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THIS
+	M=D
+	@3
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@ARG
+	M=D
+	@4
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@LCL
+	M=D
+	@RET
+	A=M
+	0;JMP
+//return end
+//decl funcClass2.get0
+(Class2.get)
+//decl funcClass2.get0end
+//pushstatic0
+	@Class2.0
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushstatic0end
+//pushstatic1
+	@Class2.1
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushstatic1end
+//sub
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M-D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//subend
+//return
+	@LCL
+	D=M
+	@FRAME
+	M=D
+	@5
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@RET
+	M=D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	@ARG
+	D=M
+	@SP
+	M=D+1
+	@1
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THAT
+	M=D
+	@2
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@THIS
+	M=D
+	@3
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@ARG
+	M=D
+	@4
+	D=A
+	@FRAME
+	A=M-D
+	D=M
+	@LCL
+	M=D
+	@RET
+	A=M
+	0;JMP
+//return end
+(END)
+	@END
+	0;JMP

--- a/projects/08/ProgramFlow/BasicLoop/BasicLoop.asm
+++ b/projects/08/ProgramFlow/BasicLoop/BasicLoop.asm
@@ -1,0 +1,207 @@
+//init
+	@256
+	D=A
+	@SP
+	M=D
+//initend
+//pushconstant0
+	@0
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant0end
+//poplocal0
+	@0
+	D=A
+	@LCL
+	M=M+D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@LCL
+	A=M
+	M=D
+	@0
+	D=A
+	@LCL
+	M=M-D
+//poplocal0end
+//label
+(LOOP_START)
+//label end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//pushlocal0
+	@0
+	D=A
+	@LCL
+	M=M+D
+	@LCL
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@LCL
+	M=M-D
+//pushlocal0end
+//add
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M+D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//addend
+//poplocal0
+	@0
+	D=A
+	@LCL
+	M=M+D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@LCL
+	A=M
+	M=D
+	@0
+	D=A
+	@LCL
+	M=M-D
+//poplocal0end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//pushconstant1
+	@1
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant1end
+//sub
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M-D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//subend
+//popargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	@0
+	D=A
+	@ARG
+	M=M-D
+//popargument0end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//ifLOOP_START
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@LOOP_START
+	D;JNE
+//ifLOOP_STARTend
+//pushlocal0
+	@0
+	D=A
+	@LCL
+	M=M+D
+	@LCL
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@LCL
+	M=M-D
+//pushlocal0end
+(END)
+	@END
+	0;JMP

--- a/projects/08/ProgramFlow/FibonacciSeries/FibonacciSeries.asm
+++ b/projects/08/ProgramFlow/FibonacciSeries/FibonacciSeries.asm
@@ -1,0 +1,353 @@
+//init
+	@256
+	D=A
+	@SP
+	M=D
+//initend
+//pushargument1
+	@1
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@1
+	D=A
+	@ARG
+	M=M-D
+//pushargument1end
+//poppointer1
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@4
+	M=D
+//poppointer1end
+//pushconstant0
+	@0
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant0end
+//popthat0
+	@0
+	D=A
+	@THAT
+	M=M+D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@THAT
+	A=M
+	M=D
+	@0
+	D=A
+	@THAT
+	M=M-D
+//popthat0end
+//pushconstant1
+	@1
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant1end
+//popthat1
+	@1
+	D=A
+	@THAT
+	M=M+D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@THAT
+	A=M
+	M=D
+	@1
+	D=A
+	@THAT
+	M=M-D
+//popthat1end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//pushconstant2
+	@2
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant2end
+//sub
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M-D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//subend
+//popargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	@0
+	D=A
+	@ARG
+	M=M-D
+//popargument0end
+//label
+(MAIN_LOOP_START)
+//label end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//ifCOMPUTE_ELEMENT
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@COMPUTE_ELEMENT
+	D;JNE
+//ifCOMPUTE_ELEMENTend
+//gotoEND_PROGRAM
+	@END_PROGRAM
+	0;JMP
+//gotoEND_PROGRAMend
+//label
+(COMPUTE_ELEMENT)
+//label end
+//pushthat0
+	@0
+	D=A
+	@THAT
+	M=M+D
+	@THAT
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@THAT
+	M=M-D
+//pushthat0end
+//pushthat1
+	@1
+	D=A
+	@THAT
+	M=M+D
+	@THAT
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@1
+	D=A
+	@THAT
+	M=M-D
+//pushthat1end
+//add
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M+D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//addend
+//popthat2
+	@2
+	D=A
+	@THAT
+	M=M+D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@THAT
+	A=M
+	M=D
+	@2
+	D=A
+	@THAT
+	M=M-D
+//popthat2end
+//pushpointer1
+	@4
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushpointer1end
+//pushconstant1
+	@1
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant1end
+//add
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M+D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//addend
+//poppointer1
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@4
+	M=D
+//poppointer1end
+//pushargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@ARG
+	A=M
+	D=M
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+	@0
+	D=A
+	@ARG
+	M=M-D
+//pushargument0end
+//pushconstant1
+	@1
+	D=A
+	@SP
+	A=M
+	M=D
+	@SP
+	M=M+1
+//pushconstant1end
+//sub
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@SP
+	M=M-1
+	A=M
+	D=M-D
+	@SP
+	M=M+1
+	A=M-1
+	M=D
+//subend
+//popargument0
+	@0
+	D=A
+	@ARG
+	M=M+D
+	@SP
+	M=M-1
+	A=M
+	D=M
+	@ARG
+	A=M
+	M=D
+	@0
+	D=A
+	@ARG
+	M=M-D
+//popargument0end
+//gotoMAIN_LOOP_START
+	@MAIN_LOOP_START
+	0;JMP
+//gotoMAIN_LOOP_STARTend
+//label
+(END_PROGRAM)
+//label end
+(END)
+	@END
+	0;JMP

--- a/projects/08/VMtranslator/CodeWriter.py
+++ b/projects/08/VMtranslator/CodeWriter.py
@@ -1,0 +1,303 @@
+from sys import argv
+from CommandType import CommandType
+
+class CodeWriter:
+    def __init__(self, name):
+        self.out = open(name.split(".")[0] + ".asm", "w")
+        self.fn = ""
+        # fn と合わせてloop labelを区別するためのindex
+        self.lc = 0
+        # 本文中 writeInitの処理
+        self.out.write("//init\n")
+        self.out.write("\t@256\n")
+        self.out.write("\tD=A\n")
+        self.out.write("\t@SP\n")
+        self.out.write("\tM=D\n")
+        self.out.write("//initend\n")
+
+    def setFileName(self, fileName):
+        self.fn = fileName.split("/")[-1][:-3]
+        self.lc = 0
+        return
+    # 二項演算のアセンブリ生成
+    def gen_bin(self, op):
+        # 1pop
+        self.out.write("\t@SP\n")
+        self.out.write("\tM=M-1\n")
+        self.out.write("\tA=M\n")
+        self.out.write("\tD=M\n")
+        # 2pop
+        self.out.write("\t@SP\n")
+        self.out.write("\tM=M-1\n")
+        self.out.write("\tA=M\n")
+        # 処理
+        self.out.write("\tD=M"+ op + "D\n")
+        # push
+        self.out.write("\t@SP\n")
+        self.out.write("\tM=M+1\n")
+        self.out.write("\tA=M-1\n")
+        self.out.write("\tM=D\n")
+        return
+    # 比較
+    def gen_cmp(self, op):
+        self.out.write("//" + op + "\n")
+        # 1pop
+        self.out.write("\t@SP\n")
+        self.out.write("\tM=M-1\n")
+        self.out.write("\tA=M\n")
+        self.out.write("\tD=M\n")
+        # 2pop
+        self.out.write("\t@SP\n")
+        self.out.write("\tM=M-1\n")
+        self.out.write("\tA=M\n")
+        # 処理
+        self.out.write("\tD=M-D\n")
+        lid = self.fn + str(self.lc)
+        self.lc += 1
+        # trueなら-1にしてくれるところに飛ぶそうでなければ0
+        self.out.write("\t@T" +lid + "\n")
+        self.out.write("\tD;" + op+ "\n")
+        self.out.write("\tD=0\n")
+        self.out.write("\t@EC" +lid + "\n")
+        self.out.write("\t0;JMP\n")
+        # push
+        #True処理
+        self.out.write("(T" + lid + ")\n")
+        self.out.write("\tD=-1\n")
+        self.out.write("\t@EC" +lid + "\n")
+        self.out.write("\t0;JMP\n")
+
+        # end output
+        self.out.write("\t(EC" +lid + ")\n")
+        self.out.write("\t@SP\n")
+        self.out.write("\tM=M+1\n")
+        self.out.write("\tA=M-1\n")
+        self.out.write("\tM=D\n")
+        self.out.write("//" + op + "end\n")
+        return
+    # unary
+    def gen_uni(self, op):
+        # sp参照して処理
+        self.out.write("//" + op + "\n")
+        self.out.write("\t@SP\n")
+        self.out.write("\tA=M-1\n")
+        self.out.write("\tM=" + op + "M\n")
+        self.out.write("//" + op + "end\n")
+
+        return
+
+    def writeArithmetic(self, command):
+        self.out.write("//" + command + "\n")
+        if command == "add":
+            self.gen_bin("+")
+        elif command == "sub":
+            self.gen_bin("-")
+        elif command == "neg":
+            self.gen_uni("-")
+        elif command == "eq":
+            self.gen_cmp("JEQ")
+        elif command == "gt":
+            self.gen_cmp("JGT")
+        elif command == "lt":
+            self.gen_cmp("JLT")
+        elif command == "and":
+            self.gen_bin("&")
+        elif command == "and":
+            self.gen_bin("|")
+        elif command == "not":
+            self.gen_uni("!")
+        self.out.write("//" + command + "end\n")
+        return
+
+    def writePushPop(self,command, segment, index):
+        if command == CommandType.C_PUSH:
+            self.out.write("//push" + segment  + str(index)+ "\n")
+            # baseからindex分ずらす必要があるものは先にbaseをずらす(popしたデータを持ってたらDが使えないので)
+            if segment in {"local", "argument", "this", "that"}:
+                self.out.write("\t@" + str(index) + "\n")
+                self.out.write("\tD=A\n")
+                if segment == "local":
+                    self.out.write("\t@LCL\n")
+                    self.out.write("\tM=M+D\n")
+                elif segment == "argument":
+                    self.out.write("\t@ARG\n")
+                    self.out.write("\tM=M+D\n")
+                elif segment == "this":
+                    self.out.write("\t@THIS\n")
+                    self.out.write("\tM=M+D\n")
+                elif segment == "that":
+                    self.out.write("\t@THAT\n")
+                    self.out.write("\tM=M+D\n")
+            # まずsegmentで参照元を決めて、データをとってくる
+            # 定数ならその数字をそのまま
+            if segment == "constant":
+                self.out.write("\t@" + str(index) + "\n")
+            elif segment == "local":
+                self.out.write("\t@LCL\n")
+                self.out.write("\tA=M\n")
+            elif segment == "argument":
+                self.out.write("\t@ARG\n")
+                self.out.write("\tA=M\n")
+            elif segment == "this":
+                self.out.write("\t@THIS\n")
+                self.out.write("\tA=M\n")
+            elif segment == "that":
+                self.out.write("\t@THAT\n")
+                self.out.write("\tA=M\n")
+            elif segment == "pointer":
+                targ = 3 + index
+                self.out.write("\t@" + str(targ) + "\n")
+            elif segment == "temp":
+                targ = 5 + index
+                self.out.write("\t@" + str(targ) + "\n")
+            #Global変数
+            elif segment == "static":
+                self.out.write("\t@" + self.fn + str(index) +"\n")
+
+            # 定数以外はアドレスをたどってデータをとる
+            if segment == "constant":
+                self.out.write("\tD=A\n")
+            else:
+                self.out.write("\tD=M\n")
+
+            #stack pointer に値をセット
+            self.out.write("\t@SP\n")
+            self.out.write("\tA=M\n")
+            self.out.write("\tM=D\n")
+            #stack pointer をincrement
+            self.out.write("\t@SP\n")
+            self.out.write("\tM=M+1\n")
+            # ずらしたbase addressを戻す
+            if segment in {"local", "argument", "this", "that"}:
+                self.out.write("\t@" + str(index) + "\n")
+                self.out.write("\tD=A\n")
+                if segment == "local":
+                    self.out.write("\t@LCL\n")
+                    self.out.write("\tM=M-D\n")
+                elif segment == "argument":
+                    self.out.write("\t@ARG\n")
+                    self.out.write("\tM=M-D\n")
+                elif segment == "this":
+                    self.out.write("\t@THIS\n")
+                    self.out.write("\tM=M-D\n")
+                elif segment == "that":
+                    self.out.write("\t@THAT\n")
+                    self.out.write("\tM=M-D\n")
+            self.out.write("//push" + segment  + str(index)+ "end\n")
+        elif command == CommandType.C_POP:
+            self.out.write("//pop" + segment  + str(index)+ "\n")
+            # baseからindex分ずらす必要があるものは先にbaseをずらす(popしたデータを持ってたらDが使えないので)
+            if segment in {"local", "argument", "this", "that"}:
+                self.out.write("\t@" + str(index) + "\n")
+                self.out.write("\tD=A\n")
+                if segment == "local":
+                    self.out.write("\t@LCL\n")
+                    self.out.write("\tM=M+D\n")
+                elif segment == "argument":
+                    self.out.write("\t@ARG\n")
+                    self.out.write("\tM=M+D\n")
+                elif segment == "this":
+                    self.out.write("\t@THIS\n")
+                    self.out.write("\tM=M+D\n")
+                elif segment == "that":
+                    self.out.write("\t@THAT\n")
+                    self.out.write("\tM=M+D\n")
+            #stack pointer から値を取得, sp decrement
+            self.out.write("\t@SP\n")
+            self.out.write("\tM=M-1\n")
+            self.out.write("\tA=M\n")
+            self.out.write("\tD=M\n")
+            # pop先Addressを参照する
+            if segment == "constant":
+                self.out.write("\t@" + str(index) + "\n")
+            elif segment == "local":
+                self.out.write("\t@LCL\n")
+                self.out.write("\tA=M\n")
+            elif segment == "argument":
+                self.out.write("\t@ARG\n")
+                self.out.write("\tA=M\n")
+            elif segment == "this":
+                self.out.write("\t@THIS\n")
+                self.out.write("\tA=M\n")
+            elif segment == "that":
+                self.out.write("\t@THAT\n")
+                self.out.write("\tA=M\n")
+            elif segment == "pointer":
+                targ = 3 + index
+                self.out.write("\t@" + str(targ) + "\n")
+            elif segment == "temp":
+                targ = 5 + index
+                self.out.write("\t@" + str(targ) + "\n")
+            # 新しいGlobal変数
+            elif segment == "static":
+                self.out.write("\t@" + self.fn + str(index) +"\n")
+            # 書き込み
+
+            self.out.write("\tM=D\n")
+            # ずらしたbase addressを戻す
+            if segment in {"local", "argument", "this", "that"}:
+                self.out.write("\t@" + str(index) + "\n")
+                self.out.write("\tD=A\n")
+                if segment == "local":
+                    self.out.write("\t@LCL\n")
+                    self.out.write("\tM=M-D\n")
+                elif segment == "argument":
+                    self.out.write("\t@ARG\n")
+                    self.out.write("\tM=M-D\n")
+                elif segment == "this":
+                    self.out.write("\t@THIS\n")
+                    self.out.write("\tM=M-D\n")
+                elif segment == "that":
+                    self.out.write("\t@THAT\n")
+                    self.out.write("\tM=M-D\n")
+            self.out.write("//pop" + segment  + str(index)+ "end\n")
+        return
+
+    def writeLabel(self, label):
+        self.out.write("//label\n")
+        self.out.write("("+ label + ")\n")
+        self.out.write("//label end\n")
+        return
+
+    def writeGoto(self, label):
+        self.out.write("//goto" + label + "\n")
+        self.out.write("\t@"+ label+ "\n")
+        self.out.write("\t0;JMP\n")
+        self.out.write("//goto" + label + "end\n")
+        return
+
+    def writeIf(self, label):
+        self.out.write("//if" + label + "\n")
+        # pop
+        self.out.write("\t@SP\n")
+        self.out.write("\tM=M-1\n")
+        self.out.write("\tA=M\n")
+        self.out.write("\tD=M\n")
+        # 0でなければJUMP
+        self.out.write("\t@"+ label+ "\n")
+        self.out.write("\tD;JNE\n")
+        self.out.write("//if" + label + "end\n")
+        return
+
+    def writeCall(self):
+        return
+
+    def writeReturn(self):
+        return
+
+    def writeFunction(self):
+        return
+    def close(self):
+        self.out.write("(END)\n")
+        self.out.write("\t@END\n")
+        self.out.write("\t0;JMP\n")
+        self.out.close()
+        return
+
+
+
+
+
+if __name__ == "__main__":
+    C = CodeWriter(argv[1])
+    print(C.out)

--- a/projects/08/VMtranslator/CommandType.py
+++ b/projects/08/VMtranslator/CommandType.py
@@ -1,0 +1,12 @@
+from enum import Enum, auto
+
+class CommandType(Enum):
+    C_ARITHMETIC = auto()
+    C_PUSH = auto()
+    C_POP = auto()
+    C_LABEL = auto()
+    C_GOTO = auto()
+    C_IF = auto()
+    C_FUNCTION = auto()
+    C_RETURN = auto()
+    C_CALL = auto()

--- a/projects/08/VMtranslator/Parser.py
+++ b/projects/08/VMtranslator/Parser.py
@@ -1,0 +1,64 @@
+from CommandType import CommandType
+import re
+class Parser:
+    def __init__(self, filename):
+        self.src = open(filename, "r")
+        self.hasMoreCommands = True
+        self.commandType = ""
+        self.arg0 = ""
+        self.arg1 = 0xffff
+
+    def advance(self):
+        l = self.src.readline()
+        if l:
+            # コメント除去、改行も
+            l = list(re.split(r"[\/\/\n]",l))[0]
+            if not l:
+                self.commandType = ""
+                self.arg0 = ""
+                self.arg1 = 0xffff
+                return
+            coms = l.split(" ")
+            # print(coms)
+
+            if coms[0] in {"add", "sub", "neg", "eq", "gt", "lt", "and", "or", "not"}:
+                self.commandType = CommandType.C_ARITHMETIC
+                self.arg0 = coms[0]
+                self.arg1 = 0xffff
+            elif coms[0] == "push":
+                self.commandType = CommandType.C_PUSH
+                self.arg0 = coms[1]
+                self.arg1 = int(coms[2])
+            elif coms[0] == "pop":
+                self.commandType = CommandType.C_POP
+                self.arg0 = coms[1]
+                self.arg1 = int(coms[2])
+            elif coms[0] == "label":
+                self.commandType = CommandType.C_LABEL
+                self.arg0 = coms[1]
+                self.arg1 = 0xffff
+            elif coms[0] == "goto":
+                self.commandType = CommandType.C_GOTO
+                self.arg0 = coms[1]
+                self.arg1 = 0xffff
+            elif coms[0] == "if-goto":
+                self.commandType = CommandType.C_IF
+                self.arg0 = coms[1]
+                self.arg1 = 0xffff
+            elif coms[0] == "function":
+                self.commandType = CommandType.C_FUNCTION
+                self.arg0 = coms[1]
+                self.arg1 = int(coms[2])
+            elif coms[0] == "return":
+                self.commandType = CommandType.C_RETURN
+                self.arg0 = ""
+                self.arg1 = 0xffff
+            elif coms[0] == "call":
+                self.commandType = CommandType.C_CALL
+                self.arg0 = coms[1]
+                self.arg1 = int(coms[2])
+        else:
+            self.hasMoreCommands = False
+            self.commandType = ""
+            self.arg0 = ""
+            self.arg1 = 0xffff

--- a/projects/08/VMtranslator/__main__.py
+++ b/projects/08/VMtranslator/__main__.py
@@ -1,0 +1,40 @@
+import os
+from sys import argv, stderr, exit
+
+from CodeWriter import CodeWriter
+from Parser import Parser
+from CommandType import CommandType
+
+
+if __name__ == "__main__":
+    if len(argv) < 2:
+        raise Exception("Usage: python3 VMtranslator $FILENAME")
+
+    C = CodeWriter(argv[1])
+    # file name リストを取得
+    try:
+        files = os.listdir(argv[1])
+    except NotADirectoryError:
+        files = [argv[1]]
+    #それぞれParse, コード生成
+    for file in files:
+        P = Parser(file)
+        C.setFileName(file)
+        while(P.hasMoreCommands):
+            P.advance()
+            if P.commandType == CommandType.C_ARITHMETIC:
+                C.writeArithmetic(P.arg0)
+            elif P.commandType == CommandType.C_PUSH:
+                C.writePushPop(P.commandType, P.arg0, P.arg1)
+            elif P.commandType == CommandType.C_POP:
+                C.writePushPop(P.commandType, P.arg0, P.arg1)
+            elif P.commandType == CommandType.C_LABEL:
+                C.writeLabel(P.arg0)
+            elif P.commandType == CommandType.C_GOTO:
+                C.writeGoto(P.arg0)
+            elif P.commandType == CommandType.C_IF:
+                C.writeIf(P.arg0)
+            # elif P.commandType == CommandType.C_FUNCTION:
+            # elif P.commandType == CommandType.C_RETURN:
+            # elif P.commandType == CommandType.C_CALL:
+    C.close()

--- a/projects/08/VMtranslator/__main__.py
+++ b/projects/08/VMtranslator/__main__.py
@@ -13,7 +13,8 @@ if __name__ == "__main__":
     C = CodeWriter(argv[1])
     # file name リストを取得
     try:
-        files = os.listdir(argv[1])
+        dirPath = "/".join(argv[1].split("/")) + "/"
+        files = [dirPath + fn for fn in os.listdir(argv[1]) if fn[-3:] == ".vm"]
     except NotADirectoryError:
         files = [argv[1]]
     #それぞれParse, コード生成
@@ -34,7 +35,10 @@ if __name__ == "__main__":
                 C.writeGoto(P.arg0)
             elif P.commandType == CommandType.C_IF:
                 C.writeIf(P.arg0)
-            # elif P.commandType == CommandType.C_FUNCTION:
-            # elif P.commandType == CommandType.C_RETURN:
-            # elif P.commandType == CommandType.C_CALL:
+            elif P.commandType == CommandType.C_FUNCTION:
+                C.writeFunction(P.arg0, P.arg1)
+            elif P.commandType == CommandType.C_RETURN:
+                C.writeReturn()
+            elif P.commandType == CommandType.C_CALL:
+                C.writeCall(P.arg0, P.arg1)
     C.close()


### PR DESCRIPTION
# VM上で分岐命令とサブルーチンの呼び出しを実装する

## 分岐
popのsp、spが要素がないところを指してるの忘れててinf時間溶かした
whileやifはアセンブリのラベルとcmpをちゃんと理解すれば書けるというのわかったのでかい

## サブルーチン呼び出し
関数のリターンアドレスってフレーム作る処理したあとに作るからフレームに一番先にpushできなくないですかって考えたけど、アセンブリはちゃんと変数として宣言してからラベルを貼れる(assemblerはラベルをちゃんと先読みしてくれる実装を自分でしたはずなんだけどなあ)ので普通に宣言してよかった。

ARGとかLCLとかの使われ方がすごいと思った(小)
returnするときに*ARGにおいておけばもともと呼び出したときのStackの状態に返り値をpushした状態になると。


リターン文とコール文が思っていたより複雑だった
コールするときには、前のスコープの状態をスコープに積む(それまで実行していたリターンアドレス、スタックの中の変数の開始位置、前の関数の引数の位置、THIS,THAT？？を積む)
リターンするときは、その関数の開始地点がLCLとしてなっているので、そこから逆にたどる1:
THAT,2:THIS,3:ARG,4:LCL,5:Return address ここらへんが慣れの問題
→リターンのときの*ARGは前のスコープのスタックトップ(フレームは引数たちからはじまる)になっていて、リターンアドレスを保存しておかないと、ジャンプ先破壊をしてしまうので注意である。

Statictestのメモリアドレスが5個ずれていた気がしている。グローバルスタックにつまれるものはgetの返り値以外ないはずだが、


